### PR TITLE
adding ankara yildirim beyazit university again

### DIFF
--- a/lib/domains/tr/edu/ybu.txt
+++ b/lib/domains/tr/edu/ybu.txt
@@ -1,0 +1,2 @@
+Ankara Yıldırım Beyazıt Üniversitesi
+Ankara Yildirim Beyazit University


### PR DESCRIPTION
It's ankara yildirim beyazit university's old domain name, we're using aybu and ybu same time (name of school has been changed)